### PR TITLE
Reduce pigz level from -9 to -6

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -172,7 +172,7 @@ if config["Do_rnaseq"] == "yes" :
                 "benchmarks/benchmark.trimmomatic_{samples}.txt"
             params:
                 trimmer = ["TRAILING:20", "LEADING:20", "MINLEN:36", "CROP:10000", "ILLUMINACLIP:"+ADAPTER+":2:30:10"],
-                compression_level="-9",
+                compression_level="-6",
                 extra = "-phred33"
             wrapper:
                 "0.47.0/bio/trimmomatic/pe"


### PR DESCRIPTION
In my opinion and according to the man gzip to have the best ratio between speed and compression we should use the -6 level
Maybe thanks to this we can observer some speed up in the trimmomatic rule but nothing impresive
> The default compression level is -6 (that is, biased towards high compression at expense of speed)
> ...
> In some rare cases, the --best option gives worse compression than the default compression level (-6). On some highly redundant files, compress compresses  better
>        than gzip.

